### PR TITLE
Improve code in Main form

### DIFF
--- a/CovidViewer/UI/Main.cs
+++ b/CovidViewer/UI/Main.cs
@@ -25,7 +25,7 @@ namespace CovidViewer.UI
         {
             try
             {
-                var Data = await _GetCovid.GetData(CountryList.SelectedValue.ToString());
+                var Data = await _GetCovid.GetData((string)CountryList.SelectedValue);
                 BinData.Add(Data);
 
                 DataBox.DataSource = BinData;
@@ -49,8 +49,7 @@ namespace CovidViewer.UI
 
         private void ClearButton_Click(object sender, EventArgs e)
         {
-            BinData.DataSource = null;
-            DataBox.Rows.Clear();
+            BinData.Clear();
         }       
 
         private void DataBox_CellContentClick(object sender, DataGridViewCellEventArgs e)


### PR DESCRIPTION
Improve code in Main form

- We can use type casting for SelectedValue instead of ToString method 
that might do some unnecessary conversion.
- We should use Clear() method for matching with Add on BindingSource control.
- Remove Rows.Clear() because datagridview will automatically sync with its data source.